### PR TITLE
Setup: Autogenerate env template files on new commits

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -1,3 +1,5 @@
+# the node environment - development when running locally
+
 NODE_ENV=
 
 SAMPLE_ENV=

--- a/.env-template
+++ b/.env-template
@@ -1,0 +1,5 @@
+NODE_ENV=
+
+SAMPLE_ENV=
+
+NEW_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules
-.env
-template.env
+*.env
 .DS_Store

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,9 +3,6 @@
 
 npm run lint:staged
 
-# delete .env templates
-# rm {*,}.env-template || true
-
 for envFile in `ls {*,.}env`
 do
   src/bin/run $envFile $envFile-template

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -6,5 +6,7 @@ npm run lint:staged
 for envFile in `ls {*,.}env`
 do
   src/bin/run $envFile $envFile-template
-  git add $envFile-template
+  # not auto-staging files to prevent 
+  # secrets getting committed by accident
+  # git add $envFile-template
 done

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,12 @@
 . "$(dirname "$0")/_/husky.sh"
 
 npm run lint:staged
+
+# delete .env templates
+# rm {*,}.env-template || true
+
+for envFile in `ls {*,.}env`
+do
+  src/bin/run $envFile $envFile-template
+  git add $envFile-template
+done

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "files.associations": {
-        ".all-contributorsrc": "json"
+        ".all-contributorsrc": "json",
+        "*.env-template": "env"
     }
 }

--- a/sample.env-template
+++ b/sample.env-template
@@ -1,1 +1,3 @@
+# sample api key
+
 OTHER_API_KEY=

--- a/sample.env-template
+++ b/sample.env-template
@@ -1,0 +1,1 @@
+OTHER_API_KEY=

--- a/template.env
+++ b/template.env
@@ -1,3 +1,0 @@
-NODE_ENV=
-
-SAMPLE_ENV=

--- a/template.env
+++ b/template.env
@@ -1,0 +1,3 @@
+NODE_ENV=
+
+SAMPLE_ENV=


### PR DESCRIPTION
Assumptions:
- env files have the extension `.env`
- templates use the extensions `.env-template`
- templates will get **not** staged whenever `.env` files change